### PR TITLE
Add strict mkdocs build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,4 +29,5 @@ jobs:
       - run: pip install mkdocs-mermaid2-plugin
       - run:  pip install mkdocs-table-reader-plugin openpyxl
       - run: pip install mkdocs-print-site-plugin
+      - run: mkdocs build --strict
       - run: mkdocs gh-deploy --force


### PR DESCRIPTION
## Summary
- run `mkdocs build --strict` before deploying docs

## Testing
- `mkdocs build --strict` *(fails: Aborted with 1 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68461bfa3c848330b238f010bce4cd0e